### PR TITLE
refactor/Send individual CAN frames instead

### DIFF
--- a/cmd/wills-race-dash-go/handleCanBusData.go
+++ b/cmd/wills-race-dash-go/handleCanBusData.go
@@ -46,37 +46,37 @@ type CANFrameMisc struct {
 }
 
 type CANFrame660 struct {
-	Type    int     `json:"Type"`
-	FrameId int			`json:"FrameId"`
-	Rpm     uint16  `json:"Rpm"`
-	Speed   uint16  `json:"Speed"`
-	Gear    uint8   `json:"Gear"`
-	Voltage float32 `json:"Voltage"`
+	Type    	int     `json:"Type"`
+	FrameId 	int			`json:"FrameId"`
+	Rpm     	uint16  `json:"Rpm"`
+	Speed   	uint16  `json:"Speed"`
+	Gear    	uint8   `json:"Gear"`
+	Voltage 	float32 `json:"Voltage"`
 }
 
 type CANFrame661 struct {
-	Type int  `json:"Type"`
-	FrameId int  `json:"Type"`
-	Iat  uint16 `json:"Iat"`
-	Ect  uint16 `json:"Ect"`
+	Type 			int  		`json:"Type"`
+	FrameId 	int  		`json:"FrameId"`
+	Iat  			uint16 	`json:"Iat"`
+	Ect  			uint16 	`json:"Ect"`
 }
 
 type CANFrame662 struct {
-	Type int    `json:"Type"`
-	FrameId int    `json:"Type"`
-	Tps  uint16 `json:"Tps"`
-	Map  uint16 `json:"Map"`
+	Type 			int    	`json:"Type"`
+	FrameId 	int    	`json:"FrameId"`
+	Tps  			uint16 	`json:"Tps"`
+	Map  			uint16 	`json:"Map"`
 }
 
 type CANFrame664 struct {
-	Type        int     `json:"Type"`
-	FrameId        int     `json:"Type"`
-	LambdaRatio float64 `json:"LambdaRatio"`
+	Type        	int     `json:"Type"`
+	FrameId       int     `json:"FrameId"`
+	LambdaRatio 	float64 `json:"LambdaRatio"`
 }
 
 type CANFrame667 struct {
 	Type         int    `json:"Type"`
-	FrameId         int    `json:"FrameId"`
+	FrameId      int    `json:"FrameId"`
 	OilTemp      uint16 `json:"OilTemp"`
 	OilPressure  uint16 `json:"OilPressure"`
 }

--- a/cmd/wills-race-dash-go/handleCanBusData.go
+++ b/cmd/wills-race-dash-go/handleCanBusData.go
@@ -196,9 +196,9 @@ func (wsConn *MySocket) HandleCanBusData() {
 		frame := canRecv.Frame()
 		jsonData := canFrameHandler.ProcessCANFrame(frame.ID, frame.Data)
 		if jsonData != nil {
-		wsConn.writeToClient(int8(frame.ID), jsonData)
+			wsConn.writeToClient(int8(frame.ID), jsonData)
+		}
 	}
-}
 }
 
 // func (wsConn *MySocket) HandleCanBusData() {

--- a/cmd/wills-race-dash-go/handleCanBusData.go
+++ b/cmd/wills-race-dash-go/handleCanBusData.go
@@ -193,15 +193,12 @@ func (wsConn *MySocket) HandleCanBusData() {
 	canFrameHandler := &CANFrameHandler{}
 
 	for canRecv.Receive() {
-		// read in the frame
 		frame := canRecv.Frame()
-		
-		// send frame to be processed, and get back the []byte
 		jsonData := canFrameHandler.ProcessCANFrame(frame.ID, frame.Data)
-		
-		// send up to client
+		if jsonData != nil {
 		wsConn.writeToClient(int8(frame.ID), jsonData)
 	}
+}
 }
 
 // func (wsConn *MySocket) HandleCanBusData() {

--- a/cmd/wills-race-dash-go/handleCanBusData.go
+++ b/cmd/wills-race-dash-go/handleCanBusData.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"go.einride.tech/can"
 	"go.einride.tech/can/pkg/socketcan"
 )
 
@@ -83,7 +84,7 @@ type CANFrame667 struct {
 
 var (
 	isDatalogging = false
-	
+
 	// --- Data conversion constants ---
 	// Oil Temp
 	A = 0.0014222095
@@ -116,53 +117,146 @@ func doDatalogging(dataloggingRunning *bool, wg *sync.WaitGroup) {
 	}
 }
 
+
+func (fh *CANFrameHandler) JsonMarshalling(frameData interface{}) []byte {
+	jsonData, err := json.Marshal(frameData)
+	if err != nil {
+		log.Println("Json Marshal error (CAN): ", err)
+		return nil
+	}
+	return jsonData
+}
+
+func (fh *CANFrameHandler) ProcessCANFrame(frameId uint32, data can.Data) []byte {
+	switch (frameId) {
+	case 69, 105:
+		wg.Add(1)
+		go doDatalogging(&isDatalogging, &wg)
+		time.Sleep(1 * time.Second)
+		isDatalogging = !isDatalogging
+		fh.FrameMisc.DataloggingAlert = isDatalogging
+		return fh.JsonMarshalling(fh.FrameMisc)
+
+	case 660, 1632:
+		fh.Frame660.Type = 1
+		fh.Frame660.FrameId = 660
+		fh.Frame660.Rpm = binary.BigEndian.Uint16(data[0:2])
+		fh.Frame660.Speed = binary.BigEndian.Uint16(data[2:4])
+		fh.Frame660.Gear = data[4]
+		fh.Frame660.Voltage = float32(data[5]) / 10.0
+		return fh.JsonMarshalling(fh.Frame660)
+	
+	case 661, 1633:
+		fh.Frame661.Type = 1
+		fh.Frame661.FrameId = 661
+		fh.Frame661.Iat = binary.BigEndian.Uint16(data[0:2])
+		fh.Frame661.Ect = binary.BigEndian.Uint16(data[2:4])
+		return fh.JsonMarshalling(fh.Frame661)
+	
+	case 662, 1634:
+		fh.Frame662.Type = 1
+		fh.Frame662.FrameId = 662
+		fh.Frame662.Tps = binary.BigEndian.Uint16(data[0:2])
+			if fh.Frame662.Tps == 65535 { fh.Frame662.Tps = 0	}
+		fh.Frame662.Map = binary.BigEndian.Uint16(data[2:4]) / 10
+		return fh.JsonMarshalling(fh.Frame662)
+	
+	case 664, 1636:
+		fh.Frame664.Type = 1
+		fh.Frame664.FrameId = 664
+		fh.Frame664.LambdaRatio = math.Round(float64(32768.0) / float64(binary.BigEndian.Uint16(data[0:2])) * 100) / 100
+		return fh.JsonMarshalling(fh.Frame664)
+	
+	case 667, 1639:
+		fh.Frame667.Type = 1
+		fh.Frame667.FrameId = 667
+		// Oil Temp
+		oilTempResistance := binary.BigEndian.Uint16(data[0:2])
+			kelvinTemp := 1 / (A + B * math.Log(float64(oilTempResistance)) + C * math.Pow(math.Log(float64(oilTempResistance)), 3))
+		fh.Frame667.OilTemp = uint16(kelvinTemp - 273.15)
+		// Oil Pressure
+		oilPressureResistance := float64(binary.BigEndian.Uint16(data[2:4])) / 819.2
+		kPaValue := ((float64(oilPressureResistance) - originalLow) / (originalHigh - originalLow) * (desiredHigh - desiredLow)) + desiredLow
+		fh.Frame667.OilPressure = uint16(math.Round(kPaValue * 0.145038)) // Convert to psi
+		return fh.JsonMarshalling(fh.Frame667)
+
+	default:
+		return nil
+	}
+}
+
 func (wsConn *MySocket) HandleCanBusData() {
 	// ---------- CANBus data ----------
 	canConn, _ := socketcan.DialContext(context.Background(), "can", appSettings.CanChannel)
 	defer canConn.Close()
-	canRecv := socketcan.NewReceiver(canConn)
-	isDatalogging := false
+	canRecv := socketcan.NewReceiver(canConn)	
+	canFrameHandler := &CANFrameHandler{}
 
 	for canRecv.Receive() {
+		// read in the frame
 		frame := canRecv.Frame()
-
-		switch frame.ID {
-		case 69, 105:
-			wg.Add(1)
-			go doDatalogging(&isDatalogging, &wg)
-			time.Sleep(1 * time.Second)
-			isDatalogging = !isDatalogging
-			canData.DataloggingAlert = isDatalogging
-		case 660, 1632:
-			canData.Rpm = binary.BigEndian.Uint16(frame.Data[0:2])
-			canData.Speed = binary.BigEndian.Uint16(frame.Data[2:4])
-			canData.Gear = frame.Data[4]
-			canData.Voltage = float32(frame.Data[5]) / 10.0
-		case 661, 1633:
-			canData.Iat = binary.BigEndian.Uint16(frame.Data[0:2])
-			canData.Ect = binary.BigEndian.Uint16(frame.Data[2:4])
-		case 662, 1634:
-			canData.Tps = binary.BigEndian.Uint16(frame.Data[0:2])
-				if canData.Tps == 65535 { canData.Tps = 0	}
-			canData.Map = binary.BigEndian.Uint16(frame.Data[2:4]) / 10
-		case 664, 1636:
-        canData.LambdaRatio = math.Round(float64(32768.0) / float64(binary.BigEndian.Uint16(frame.Data[0:2])) * 100) / 100
-		case 667, 1639:
-			// Oil Temp
-			oilTempResistance := binary.BigEndian.Uint16(frame.Data[0:2])
-        kelvinTemp := 1 / (A + B * math.Log(float64(oilTempResistance)) + C * math.Pow(math.Log(float64(oilTempResistance)), 3))
-			canData.OilTemp = uint16(kelvinTemp - 273.15)
-			// Oil Pressure
-			oilPressureResistance := float64(binary.BigEndian.Uint16(frame.Data[2:4])) / 819.2
-			kPaValue := ((float64(oilPressureResistance) - originalLow) / (originalHigh - originalLow) * (desiredHigh - desiredLow)) + desiredLow
-			canData.OilPressure = uint16(math.Round(kPaValue * 0.145038)) // Convert to psi
-		}
-
-		jsonData, err := json.Marshal(canData)
-		if err != nil {
-			log.Println("Json Marshal error (CAN): ", err)
-			return
-		}
-		wsConn.writeToClient(canData.Type, jsonData)
+		
+		// send frame to be processed, and get back the []byte
+		jsonData := canFrameHandler.ProcessCANFrame(frame.ID, frame.Data)
+		
+		// send up to client
+		wsConn.writeToClient(int8(frame.ID), jsonData)
 	}
 }
+
+// func (wsConn *MySocket) HandleCanBusData() {
+// 	// ---------- CANBus data ----------
+// 	canConn, _ := socketcan.DialContext(context.Background(), "can", appSettings.CanChannel)
+// 	defer canConn.Close()
+// 	canRecv := socketcan.NewReceiver(canConn)
+// 	isDatalogging := false
+// 	canData := CanData{Type: 1}
+
+// 	for canRecv.Receive() {
+// 		frame := canRecv.Frame()
+
+// 		switch frame.ID {
+// 		case 69, 105:
+// 			wg.Add(1)
+// 			go doDatalogging(&isDatalogging, &wg)
+// 			time.Sleep(1 * time.Second)
+// 			isDatalogging = !isDatalogging
+// 			canData.DataloggingAlert = isDatalogging
+		
+// 		case 660, 1632:
+// 			canData.Rpm = binary.BigEndian.Uint16(frame.Data[0:2])
+// 			canData.Speed = binary.BigEndian.Uint16(frame.Data[2:4])
+// 			canData.Gear = frame.Data[4]
+// 			canData.Voltage = float32(frame.Data[5]) / 10.0
+		
+// 		case 661, 1633:
+// 			canData.Iat = binary.BigEndian.Uint16(frame.Data[0:2])
+// 			canData.Ect = binary.BigEndian.Uint16(frame.Data[2:4])
+		
+// 		case 662, 1634:
+// 			canData.Tps = binary.BigEndian.Uint16(frame.Data[0:2])
+// 				if canData.Tps == 65535 { canData.Tps = 0	}
+// 			canData.Map = binary.BigEndian.Uint16(frame.Data[2:4]) / 10
+		
+// 		case 664, 1636:
+// 			canData.LambdaRatio = math.Round(float64(32768.0) / float64(binary.BigEndian.Uint16(frame.Data[0:2])) * 100) / 100
+		
+// 		case 667, 1639:
+// 			// Oil Temp
+// 			oilTempResistance := binary.BigEndian.Uint16(frame.Data[0:2])
+//         kelvinTemp := 1 / (A + B * math.Log(float64(oilTempResistance)) + C * math.Pow(math.Log(float64(oilTempResistance)), 3))
+// 			canData.OilTemp = uint16(kelvinTemp - 273.15)
+// 			// Oil Pressure
+// 			oilPressureResistance := float64(binary.BigEndian.Uint16(frame.Data[2:4])) / 819.2
+// 			kPaValue := ((float64(oilPressureResistance) - originalLow) / (originalHigh - originalLow) * (desiredHigh - desiredLow)) + desiredLow
+// 			canData.OilPressure = uint16(math.Round(kPaValue * 0.145038)) // Convert to psi
+// 		}
+
+// 		jsonData, err := json.Marshal(canData)
+// 		if err != nil {
+// 			log.Println("Json Marshal error (CAN): ", err)
+// 			return
+// 		}
+// 		wsConn.writeToClient(canData.Type, jsonData)
+// 	}
+// }

--- a/cmd/wills-race-dash-go/handleCanBusData.go
+++ b/cmd/wills-race-dash-go/handleCanBusData.go
@@ -30,8 +30,59 @@ type CanData struct {
   DataloggingAlert bool
 }
 
+type CANFrameHandler struct {
+	FrameMisc CANFrameMisc
+	Frame660 CANFrame660
+	Frame661 CANFrame661
+	Frame662 CANFrame662
+	Frame664 CANFrame664
+	Frame667 CANFrame667
+}
+
+type CANFrameMisc struct {
+	Type 							int
+	DataloggingAlert 	bool
+}
+
+type CANFrame660 struct {
+	Type    int     `json:"Type"`
+	FrameId int			`json:"FrameId"`
+	Rpm     uint16  `json:"Rpm"`
+	Speed   uint16  `json:"Speed"`
+	Gear    uint8   `json:"Gear"`
+	Voltage float32 `json:"Voltage"`
+}
+
+type CANFrame661 struct {
+	Type int  `json:"Type"`
+	FrameId int  `json:"Type"`
+	Iat  uint16 `json:"Iat"`
+	Ect  uint16 `json:"Ect"`
+}
+
+type CANFrame662 struct {
+	Type int    `json:"Type"`
+	FrameId int    `json:"Type"`
+	Tps  uint16 `json:"Tps"`
+	Map  uint16 `json:"Map"`
+}
+
+type CANFrame664 struct {
+	Type        int     `json:"Type"`
+	FrameId        int     `json:"Type"`
+	LambdaRatio float64 `json:"LambdaRatio"`
+}
+
+type CANFrame667 struct {
+	Type         int    `json:"Type"`
+	FrameId         int    `json:"FrameId"`
+	OilTemp      uint16 `json:"OilTemp"`
+	OilPressure  uint16 `json:"OilPressure"`
+}
+
+
 var (
-	canData       = CanData{Type: 1}
+	isDatalogging = false
 	
 	// --- Data conversion constants ---
 	// Oil Temp

--- a/web/LapTimingDisplay/index.js
+++ b/web/LapTimingDisplay/index.js
@@ -37,18 +37,29 @@ document.addEventListener('DOMContentLoaded', () => {
     
     switch (data.Type) {
       case 1:
-        // RPM progressive bar
-        rpmBar.style.width = ((data.Rpm / 9000) * 100) + '%';
-        tpsBar.style.height = data.Tps + '%';
-        rpmNum.textContent = data.Rpm;
-        speed.textContent = data.Speed;
-        gear.textContent = data.Gear;
-        voltage.textContent = data.Voltage;
-        iat.textContent = data.Iat;
-        ect.textContent = data.Ect;
-        lambdaRatio.textContent = data.LambdaRatio;
-        oilTemp.textContent = data.OilTemp;
-        oilPressure.textContent = data.OilPressure;
+        switch (data.FrameId) {
+          case 660:
+            rpmBar.style.width = ((data.Rpm / 9000) * 100) + '%';
+            tpsBar.style.height = data.Tps + '%';
+            rpmNum.textContent = data.Rpm;
+            speed.textContent = data.Speed;
+            break;
+          case 661:
+            gear.textContent = data.Gear;
+            voltage.textContent = data.Voltage;
+            break;
+          case 662:
+            iat.textContent = data.Iat;
+            ect.textContent = data.Ect;
+            break;
+          case 664:
+            lambdaRatio.textContent = data.LambdaRatio;
+            break;
+          case 667:
+            oilTemp.textContent = data.OilTemp;
+            oilPressure.textContent = data.OilPressure;
+            break;
+        }
         break;
       case 2:
         var currentLapMinutes = Math.floor((data.CurrentLapTime % 3600000) / 60000);

--- a/web/LapTimingDisplay/index.js
+++ b/web/LapTimingDisplay/index.js
@@ -34,23 +34,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   socket.onmessage = function(event) {
     const data = JSON.parse(event.data);
-    
     switch (data.Type) {
       case 1:
         switch (data.FrameId) {
           case 660:
             rpmBar.style.width = ((data.Rpm / 9000) * 100) + '%';
-            tpsBar.style.height = data.Tps + '%';
             rpmNum.textContent = data.Rpm;
             speed.textContent = data.Speed;
-            break;
-          case 661:
             gear.textContent = data.Gear;
             voltage.textContent = data.Voltage;
             break;
-          case 662:
+          case 661:
             iat.textContent = data.Iat;
             ect.textContent = data.Ect;
+            break;
+          case 662:
+            tpsBar.style.height = data.Tps + '%';
             break;
           case 664:
             lambdaRatio.textContent = data.LambdaRatio;


### PR DESCRIPTION
The dash has always read in message by message, but sent the whole dataset to the client and rerendered everything. It will now only update the backend value for the specific can message being read, and only send that dataset to the client and only re-render that

Hoping to gain some performance from this..